### PR TITLE
Docs + trazabilidad + plantilla de PR (Fixes #3)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+\## Resumen
+
+&nbsp;
+
+\## Issue relacionado
+
+Fixes #
+
+&nbsp;
+
+\## Checklist
+
+\- \[ ] El PR referencia el Issue (Fixes #...)
+
+\- \[ ] Se agregaron evidencias en `docs/evidencias/` (si aplica)
+
+\- \[ ] Se validó que el cambio no rompe el proyecto (compila / abre / navega)
+
+\- \[ ] No se subieron secretos (tokens, claves, contraseñas)
+
+\- \[ ] No se subieron rutas locales ni capturas con datos sensibles
+
+&nbsp;
+
+\## Evidencia
+
+\- Link/archivo: (colocar ruta o enlace dentro del repo)
+

--- a/README.md
+++ b/README.md
@@ -1,47 +1,79 @@
 # App Monitoreo de Calidad de Aire (Android + ESP32 + PHP + MySQL)
-
-## Descripción
-Sistema de monitoreo de calidad de aire con:
-- App Android para configurar y visualizar lecturas.
-- ESP32 con sensores DHT11 (temperatura/humedad) y MQ135 (gas), y pantalla TFT.
-- Backend PHP en XAMPP.
-- Base de datos MySQL local para almacenar lecturas e historial.
-
-## Flujo general
-1) El ESP32 arranca en Modo AP si no está configurado:
-   - SSID: SensorAire-ESP32
-   - Clave: 12345678
-2) La app se conecta al WiFi del ESP32 y envía configuración por HTTP:
-   - POST http://192.168.4.1/config con ssid, password, token, serverUrl
-3) El ESP32 reinicia, se conecta a la red local (STA) y envía lecturas al backend:
-   - POST JSON a serverUrl con token, co2, temperatura, humedad, pm25, calidad_aire_indice
-4) El backend guarda lecturas en MySQL local.
-
-## Estructura del repositorio
-- src/mobile: proyecto Android
-- src/firmware: código del ESP32 (Arduino)
-- src/backend: backend PHP (XAMPP)
-- database: scripts SQL para crear BD
-- docs: documentación (SRS, SDD, calidad, ciclo)
-- tests: plan de pruebas
-- CM_PLAN.md: plan de gestión de configuración
-- CHANGELOG.md: historial de versiones
-
-## Puesta en marcha (resumen)
-1) Firmware ESP32:
-   - Abrir el .ino en Arduino IDE
-   - Configurar librerías (WiFi, WebServer, DHT, Adafruit_ILI9341)
-   - Compilar y cargar al ESP32
-
-2) Backend PHP (XAMPP):
-   - Copiar src/backend/php a htdocs (o ajustar rutas)
-   - Crear la base en MySQL usando database/schema.sql
-   - Configurar variables en config/backend.env (local)
-
-3) App Android:
-   - Abrir src/mobile/MonitoreoAireApp en Android Studio
-   - Compilar e instalar
-   - Conectarse al AP del ESP32 y realizar provisioning
-
+ 
+## ¿Qué es este proyecto?
+Este proyecto es un sistema para registrar y visualizar mediciones relacionadas con la calidad del aire. La solución está pensada para funcionar con un dispositivo (ESP32 + sensores), pero también permite entender la estructura del sistema y revisar gran parte del trabajo sin tener el hardware.
+ 
+## Componentes (qué hace cada parte)
+- **App Android (src/mobile)**: interfaz para ver lecturas, configurar parámetros y revisar pantallas del sistema.
+- **Firmware ESP32 (src/firmware)**: lógica del dispositivo que lee sensores y envía lecturas al servidor.
+- **Backend PHP (src/backend)**: recibe datos (lecturas) y los guarda en la base de datos.
+- **Base de datos MySQL (database)**: estructura de tablas y scripts para crear el esquema.
+- **Documentación (docs)**: SRS, SDD, calidad, ciclo de vida y evidencias.
+- **Pruebas (tests y docs)**: evidencia y documentación de validaciones.
+ 
+## Flujo general (explicado simple)
+1) El **dispositivo (ESP32)** obtiene mediciones de sensores.
+2) Esas mediciones se envían al **backend (PHP)**.
+3) El backend guarda los datos en **MySQL**.
+4) La **app Android** permite configurar y visualizar la información.
+ 
+## Cómo revisar el proyecto sin conocer el hardware
+Aunque no tengas ESP32 ni sensores, puedes entender y verificar el repositorio así:
+ 
+### 1) Revisar documentación y estructura (sin ejecutar nada)
+- Abre `docs/` para ver la documentación del proyecto (SRS, SDD, Quality, Lifecycle).
+- Revisa `CM_PLAN.md` y `CHANGELOG.md` para entender control de configuración y versiones.
+- Mira `database/` para ver el esquema y cómo se almacenan las lecturas.
+ 
+### 2) Revisar la app Android sin ESP32
+Puedes abrir la app en Android Studio y revisar pantallas, navegación y configuración:
+- Ruta: `src/mobile`
+- Qué puedes validar sin hardware:
+  - Que el proyecto compile.
+  - Que las pantallas carguen y la navegación funcione.
+  - Que los formularios y vistas se vean correctamente.
+  - Que las opciones de configuración estén disponibles (aunque no se conecte a un ESP32 real).
+ 
+### 3) Revisar backend y base de datos (sin dispositivo)
+Puedes levantar el backend localmente y revisar que los endpoints y el guardado existan:
+- Ruta: `src/backend`
+- Base de datos: scripts en `database/`
+- Qué puedes validar sin hardware:
+  - Que el backend esté organizado y tenga archivos de recepción/registro.
+  - Que el esquema SQL exista y sea coherente con lo que se guarda.
+  - Que el backend tenga configuración separada (sin incluir claves reales).
+ 
+## Puesta en marcha (cuando sí hay hardware)
+### 1) Firmware ESP32
+- Abrir el `.ino` en Arduino IDE.
+- Instalar librerías necesarias.
+- Compilar y cargar al ESP32.
+ 
+### 2) Backend PHP (XAMPP)
+- Copiar `src/backend/php` a `htdocs` (o ajustar rutas).
+- Crear la base en MySQL usando scripts en `database/`.
+- Configurar variables locales (evitar subir secretos al repo).
+ 
+### 3) App Android
+- Abrir el proyecto en Android Studio desde `src/mobile`.
+- Compilar e instalar en un celular/emulador.
+- Conectarse al dispositivo (cuando el ESP32 esté disponible) y hacer la configuración.
+ 
+## Estructura del repositorio (guía rápida)
+- `src/mobile`: app Android
+- `src/firmware`: código ESP32 (Arduino)
+- `src/backend`: backend PHP
+- `database`: scripts SQL
+- `docs`: documentación y evidencias
+- `tests`: pruebas
+- `CM_PLAN.md`: plan de gestión de configuración
+- `CHANGELOG.md`: historial de versiones
+ 
+## Evidencias
+Las capturas y evidencias verificables se guardan en:
+- `docs/evidencias/funcional/` (pruebas funcionales)
+- `docs/evidencias/auditoria_fisica_issue1/` (auditoría física del repositorio)
+- `docs/evidencias/trazabilidad_issue3/` (trazabilidad y documentación)
+ 
 ## Línea base
-La versión v1.0 representa la línea base inicial (estructura GCS + fuentes + documentación mínima).
+La versión `v1.0` representa la línea base inicial del proyecto (estructura GCS, fuentes y documentación mínima).

--- a/docs/evidencias/trazabilidad_issue3/README.md
+++ b/docs/evidencias/trazabilidad_issue3/README.md
@@ -1,0 +1,8 @@
+\## v1.1.1 - PENDIENTE
+
+\- Auditoría física: evidencias y organización en /docs.
+
+\- Auditoría funcional: evidencias de pruebas funcionales.
+
+\- Trazabilidad: tabla de trazabilidad + plantilla de PR + mejora de README para entender el proyecto sin hardware.
+

--- a/docs/trazabilidad.md
+++ b/docs/trazabilidad.md
@@ -1,0 +1,20 @@
+\# Trazabilidad del proyecto
+
+&nbsp;
+
+Esta tabla conecta los elementos principales de control de configuración: Issue -> Rama -> PR -> Commit -> Evidencia -> Release.
+
+El campo \*\*Release\*\* queda como \*\*PENDIENTE\*\* hasta publicarlo en GitHub.
+
+&nbsp;
+
+| Issue | Rama | PR | Commit(s) | Evidencia | Release |
+
+|---|---|---|---|---|---|
+
+| #1 Auditoría física    | audit/fisica-1 | PR # 5 | a392465, 8d2c34c | docs/evidencias/auditoria\_fisica\_issue1/ | PENDIENTE |
+
+| #2 Auditoría funcional | (rama de funcional) | PR # 4| dcf701f, 51e6c54  | docs/pruebas\_funcionales.md + docs/evidencias/funcional/ | PENDIENTE |
+
+| #3 Docs + Trazabilidad | audit/docs-traza-3 | PR # (este PR) | (se llena al final) | docs/trazabilidad.md + plantilla PR + captura PR | PENDIENTE |
+


### PR DESCRIPTION
Fixes #3
 
Se mejoró README para entender el proyecto sin conocer hardware.
Se agregó docs/trazabilidad.md y plantilla .github/PULL_REQUEST_TEMPLATE.md.
Se creó docs/evidencias/trazabilidad_issue3/ para evidencias del PR y cambios.
Se actualizó CHANGELOG para v1.1.1 (PENDIENTE).